### PR TITLE
Updating PHP CS fixer to newer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
     "coding standard"
   ],
   "require": {
-    "friendsofphp/php-cs-fixer": "^2.12"
+    "friendsofphp/php-cs-fixer": "^2.16.1"
   }
 }


### PR DESCRIPTION
Current version is not compatible with PHP 7.2. This upgrade will allow us to use it against any 7.x version.

Before approval, maybe we should talk how to test this upgrade before sending it to production.