### PR TITLE
DOPS-12255: Beta ruleset

### DIFF
--- a/beta-rules.php
+++ b/beta-rules.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+    '@PSR2' => true,
+
+    // PHPDOC
+    'general_phpdoc_annotation_remove' => ['annotations' => ['author', 'package', 'group']],
+    'no_empty_phpdoc' => true,
+    'no_superfluous_phpdoc_tags' => true,
+
+    // CASTING
+    // A single space should be between cast and variable.
+    'cast_spaces' => ['space' => 'single'],
+    // @PSR12, cast should be written in lower case.
+    'lowercase_cast' => true,
+    // Replaces intval, floatval, doubleval, strval and boolval function calls with respective type casting operator.
+    'modernize_types_casting' => true,
+    //Short cast bool using double exclamation mark should not be used.
+    'no_short_bool_cast' => true,
+    // Variables must be set null instead of using (unset) casting.
+    'no_unset_cast' => true,
+    // @PSR12, cast (boolean), (integer), (double), (real) and (binary) as (bool), (int), (float) and (string).
+    'short_scalar_cast' => true,
+
+    // ARRAYS
+    // PHP arrays should be declared using the short syntax $arr = [].
+    'array_syntax' => ['syntax' => 'short'],
+    // Operator => should not be surrounded by multi-line whitespaces.
+    'no_multiline_whitespace_around_double_arrow' => true,
+    // In array declaration, there MUST NOT be a whitespace before each comma.
+    'no_whitespace_before_comma_in_array' => true,
+    // In array declaration, there MUST be exactly one whitespace after each comma.
+    'whitespace_after_comma_in_array' => true,
+    // Array index should always be written by using square braces.
+    'normalize_index_brace' => true,
+    // Arrays should be formatted like function/method arguments, without leading or trailing single line space.
+    'trim_array_spaces' => true,
+
+    // GENERAL FORMATTING
+    'blank_line_after_opening_tag' => true,
+    'object_operator_without_whitespace' => true,
+    'no_whitespace_in_blank_line' => true,
+    'standardize_not_equals' => true,
+    'no_extra_blank_lines' => ['tokens' => ['extra']],
+
+    // POTENTIALLY DANGEROUS! These rules can change semantics of existing code!
+    // Replace non multibyte-safe functions with corresponding mb function.
+    'mb_str_functions' => true,
+    // Force strict types declaration in all files. Requires PHP >= 7.0.
+    'declare_strict_types' => true,
+];

--- a/beta-rules.php
+++ b/beta-rules.php
@@ -37,7 +37,6 @@ return [
     'trim_array_spaces' => true,
 
     // GENERAL FORMATTING
-    'blank_line_after_opening_tag' => true,
     'object_operator_without_whitespace' => true,
     'no_whitespace_in_blank_line' => true,
     'standardize_not_equals' => true,

--- a/rules.php
+++ b/rules.php
@@ -2,7 +2,14 @@
 
 return [
     '@PSR2' => true,
+
+    // ARRAYS
+    // PHP arrays should be declared using the short syntax $arr = [].
     'array_syntax' => ['syntax' => 'short'],
+    // Operator => should not be surrounded by multi-line whitespaces.
+    'no_multiline_whitespace_around_double_arrow' => true,
+
+    // GENERAL FORMATTING
     'object_operator_without_whitespace' => true,
     'no_whitespace_in_blank_line' => true,
     'standardize_not_equals' => true,


### PR DESCRIPTION
Built ontop of https://github.com/arbor-education/php-coding-standard/pull/10 this pr adds a beta ruleset to a seperate config. The aim behind this is to introduce a staging area that we can run alongside the accepted rulesets prior to elevating them if they do not throw up any issues.

We added the blank_line_after_opening_tag however that conflicts (IMO) what declare_strict types format we want to adopt. Can be added back in depending on what we adopt.