### PR TITLE
Add unit test covers tag rule

### DIFF
--- a/beta-rules.php
+++ b/beta-rules.php
@@ -6,6 +6,7 @@ return [
     // PHPDOC
     'no_empty_phpdoc' => true,
     'no_superfluous_phpdoc_tags' => true,
+    'php_unit_test_class_requires_covers' => true,
 
     // CASTING
     // A single space should be between cast and variable.


### PR DESCRIPTION
Hello. Adding a @covers tag to the top of unit test classes makes test coverage reports more accurate. Specifying the class(es) that a unit test is covering means PHPUnit won't consider other classes that are used in the test when totting up invoked code - so we avoid false positives.  We have quite a few tests without this info and I've tested adding it into our tests in group and it does make a material difference.