### PR TITLE
DOPS-15477 Add Secret Scanner Workflow

### DIFF
--- a/.github/workflows/secret-scanner.yaml
+++ b/.github/workflows/secret-scanner.yaml
@@ -1,0 +1,16 @@
+name: "Secret Scanner"
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  secrets-scanner:
+    uses: arbor-education/gha.workflows/.github/workflows/secret-scanner-template.yaml@DOPS-12604-cicd-scanner
+    secrets:
+      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/secret-scanner.yaml
+++ b/.github/workflows/secret-scanner.yaml
@@ -13,4 +13,4 @@ jobs:
   secrets-scanner:
     uses: arbor-education/gha.workflows/.github/workflows/secret-scanner-template.yaml@v1
     secrets:
-      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+      JIRA_SA_CREATE_ISSUE: ${{ secrets.JIRA_SA_CREATE_ISSUE }}

--- a/.github/workflows/secret-scanner.yaml
+++ b/.github/workflows/secret-scanner.yaml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   secrets-scanner:
-    uses: arbor-education/gha.workflows/.github/workflows/secret-scanner-template.yaml@DOPS-12604-cicd-scanner
+    uses: arbor-education/gha.workflows/.github/workflows/secret-scanner-template.yaml@v1
     secrets:
       JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,3 @@
+repos:
+  - repo: arbor-education/gha.workflows/.github/workflows/pre-commit-template.yaml
+    rev: v0.0.168

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,17 @@
 repos:
-  - repo: local
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+        exclude: '\.github/actions/.*/dist/.*'
+      - id: end-of-file-fixer
+        exclude: '\.github/actions/.*/dist/.*'
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-yaml
+
+  - repo: https://github.com/arbor-education/gha.workflows
+    rev: c593aa60a9207ddc5c553561f9580b25d88fe5bc
     hooks:
       - id: trufflehog
-        name: TruffleHog
-        description: Detect secrets using TruffleHog.
-        entry: bash -c 'trufflehog git file://. --since-commit HEAD --results=verified --fail --no-update'
-        language: system
-        pass_filenames: false
-        stages: ["pre-commit", "pre-push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,22 @@
 repos:
-  - repo: https://github.com/arbor-education/gha.workflows
-    rev: v2.0.51
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
     hooks:
-      - id: arbor-standard
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+        exclude: '\.github/actions/.*/dist/.*'
+      - id: end-of-file-fixer
+        exclude: '\.github/actions/.*/dist/.*'
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-yaml
+
+  - repo: local
+    hooks:
       - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets using TruffleHog.
+        entry: bash -c 'if ! command -v trufflehog &>/dev/null; then echo "ERROR: trufflehog is not installed."; echo "Install it via: curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin"; exit 1; fi; trufflehog git file://. --since-commit HEAD --results=verified --fail --no-update'
+        language: system
+        pass_filenames: false
+        stages: ["pre-commit", "pre-push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,6 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
-    hooks:
-      - id: check-merge-conflict
-      - id: trailing-whitespace
-        exclude: '\.github/actions/.*/dist/.*'
-      - id: end-of-file-fixer
-        exclude: '\.github/actions/.*/dist/.*'
-      - id: check-json
-      - id: check-added-large-files
-      - id: check-yaml
-
   - repo: https://github.com/arbor-education/gha.workflows
-    rev: c593aa60a9207ddc5c553561f9580b25d88fe5bc
+    rev: 444cca24015f1cfcb80de1d6deb881a5ae58e30d
     hooks:
+      - id: arbor-standard
       - id: trufflehog

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
 repos:
-  - repo: arbor-education/gha.workflows/.github/workflows/pre-commit-template.yaml
-    rev: v0.0.168
+  - repo: local
+    hooks:
+      - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets using TruffleHog.
+        entry: bash -c 'trufflehog git file://. --since-commit HEAD --results=verified --fail --no-update'
+        language: system
+        pass_filenames: false
+        stages: ["pre-commit", "pre-push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/arbor-education/gha.workflows
-    rev: 444cca24015f1cfcb80de1d6deb881a5ae58e30d
+    rev: v2.0.51
     hooks:
       - id: arbor-standard
       - id: trufflehog


### PR DESCRIPTION
DOPS-15477 Add secret scanning and standard pre-commit checks to this repository.

Changes:
- `.github/workflows/secret-scanner.yaml` — runs TruffleHog on every push and PR via the shared `secret-scanner-template.yaml@v1` reusable workflow
- `.pre-commit-config.yaml` — standard pre-commit hooks (merge-conflict, whitespace, file format) plus a local TruffleHog hook for pre-commit and pre-push; includes install instructions if TruffleHog is not on the developer's machine