### PR TITLE
ATLAS-132 fix ordering rules, remove dupes

### DIFF
--- a/beta-rules.php
+++ b/beta-rules.php
@@ -1,9 +1,6 @@
 <?php
 
 return [
-    '@PSR2' => true,
-    '@PSR12' => true,
-
     // PHPDOC rules that may cause breaking changes in model files
     'no_superfluous_phpdoc_tags' => true,
 ];

--- a/rules.php
+++ b/rules.php
@@ -5,7 +5,10 @@ return [
     '@PSR12' => true,
 
     // IMPORTS
-    'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    'ordered_imports' => [
+        'sort_algorithm' => 'alpha', //stricter PSR12 requirements
+        'imports_order' => ['class', 'function', 'const'] //PSR12
+    ],
 
     // CASTING
     // A single space should be between cast and variable.


### PR DESCRIPTION
## Summary of changes
[ATLAS-132](https://orchard.atlassian.net/browse/ATLAS-132)
- make class ordering rules more specific to avoid conflicts between PSR12 & ordering rules
- remove duplicated PSR rules from beta set - these are designed to be merged with normal rules.

### Areas to focus on

### Notes for code owners 

### Breaking changes


[ATLAS-132]: https://orchard.atlassian.net/browse/ATLAS-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens import ordering to PSR-12 in `rules.php` and removes duplicate PSR presets from `beta-rules.php`.
> 
> - **Coding Standards**:
>   - Update `rules.php` `ordered_imports` to include `imports_order` (`['class', 'function', 'const']`) with `sort_algorithm: 'alpha'`.
> - **Beta ruleset**:
>   - Remove `@PSR2` and `@PSR12` from `beta-rules.php`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed9c3a74c7fb037177c52117f72d9c15e37bc128. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->